### PR TITLE
Remove tool.ruff.target-version from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ authors = [
 ]
 version = "0.1.0"
 readme = "README.md"
+# Target Python 3.12. If you decide to use a different version of Python
+# you will need to update this value.
 requires-python = ">=3.12"
 dependencies = []
 
@@ -25,9 +27,6 @@ dev = [
 # The original reason for this limit was a standard vim terminal is only 79 characters,
 # but this doesn't really apply anymore.
 line-length = 119
-# Target Python 3.12. If you decide to use a different version of Python
-# you will need to update this value.
-target-version = "py312"
 # Automatically fix auto-fixable issues.
 fix = true
 # The directory containing the source code. If you choose a different project layout


### PR DESCRIPTION
Ruff can find the version from `project.requires-python`, and recommends not setting both it and `tool.ruff.target-version`, so this PR removes the `target-version` entry. It also moves the associated comment to `project.requries-python`. See the [Ruff target-version docs](https://docs.astral.sh/ruff/settings/#target-version) for more details.