### PR TITLE
Update LICENSE.txt with team GitHub names and year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2021 Python Discord
+Copyright 2025 Mannyvv, afx8732, enskyeing, husseinhirani, jks85, MeGaGiGaGon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Per the template `README.md`, we should update the `LICENSE.txt` file with our team names once the jam starts. I also updated the year to 2025.