### PR TITLE
Update .gitignore with uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ build/
 .vscode/
 # MacOS
 .DS_Store
+
+# Since uv is not required for the project and all dependancies are pinned,
+# ignore the lock file for the convenience of people using uv
+uv.lock


### PR DESCRIPTION
Since uv is not required for the project, and all dependencies are pinned, this will help anyone using uv to not have to constantly exclude the lock file from `git add`s