### PR TITLE
Add WPM-test page

### DIFF
--- a/src/input_method_proto.py
+++ b/src/input_method_proto.py
@@ -1,0 +1,9 @@
+import typing
+
+
+class IInputMethod(typing.Protocol):
+    """An interface for any input method renderable in the WPM test page."""
+
+    def on_text_update(self, callback: typing.Callable[[str], None]) -> None:
+        """Call `callback` every time the user input changes."""
+        raise NotImplementedError

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,7 @@
 from nicegui import ui
 
-ui.label("Hello NiceGUI!")
+import wpm_tester
+
+ui.page("/test/{method}")(wpm_tester.wpm_tester_page)
 
 ui.run()

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
 from nicegui import ui
 # We probably want to figure out a more clean way to do this without the noqa.
 import rpg_text_input as _  # noqa: F401 Importing creates the subpage.
+import wpm_tester
 
 ui.label("Hello NiceGUI!")
 ui.page("/test/{method}")(wpm_tester.wpm_tester_page)
 
 ui.run()
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from nicegui import ui
+
 # We probably want to figure out a more clean way to do this without the noqa.
 import rpg_text_input as _  # noqa: F401 Importing creates the subpage.
 import wpm_tester
@@ -7,4 +8,3 @@ ui.label("Hello NiceGUI!")
 ui.page("/test/{method}")(wpm_tester.wpm_tester_page)
 
 ui.run()
-

--- a/src/wpm_tester.py
+++ b/src/wpm_tester.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+from nicegui import ui
+
+import input_method_proto
+import input_view
+
+
+def get_input_method_by_name(inmth: str) -> type[input_method_proto.IInputMethod] | None:  # noqa: ARG001 temporary
+    """Get an input method class by it's name.
+
+    :returns: `type[IInputMethod]` on success, `None` on failure.
+    """
+    return None
+
+
+@dataclass
+class WpmTesterPageState:
+    """The page state."""
+
+    """Useless for now, may be useful later?"""
+    text: str
+
+
+async def wpm_tester_page(method: str) -> None:
+    """Create the actual page which tests the wpm.
+
+    Usage:
+        In main.py, use @ui.page("/test/{method}")(this) then this takes
+        the method from the url
+    """
+    state = WpmTesterPageState("")
+
+    input_method_def = get_input_method_by_name(method)
+    if input_method_def is None:
+        ui.navigate.to("/")
+        return
+
+    with ui.header(elevated=True).classes("align-center justify-center"):
+        ui.label(f"test: {method}").classes("text-center text-lg")
+
+    # TODO: get og text from babbler module
+    iv = input_view.input_view("the quick brown fox jumps over the lazy dog").classes("w-full")
+
+    input_method = input_method_def()
+
+    def on_text_update(txt: str) -> None:
+        iv.set_text(txt)
+        state.text = txt
+
+    input_method.on_text_update(on_text_update)


### PR DESCRIPTION
This firstly makes the `input_method_proto` module, which defines an interface for input methods to follow. The interface is to allow the WPM-test page module to only have to worry about one implementation of input method rather than having special handling for each one.

Closes #23 