### PR TITLE
Update pyproject.toml to exclude COM812

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,6 @@ ignore = [
     "TD002",
     "TD003",
     "FIX",
+    # Conflicts with formatter.
+    "COM812",
 ]


### PR DESCRIPTION
According to a warning I occasionally get, we should exclude this lint.
> warning: The following rule may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `lint.select` or `lint.extend-select` configuration, or adding it to the `lint.ignore` configuration.
