### PR TITLE
Update audio_style_input to use builtin string constants more

### DIFF
--- a/src/audio_style_input/__init__.py
+++ b/src/audio_style_input/__init__.py
@@ -10,11 +10,7 @@ import input_method_proto
 media = Path("./static")
 app.add_media_files("/media", media)
 
-capital_letters = [chr(i) for i in range(ord("A"), ord("Z") + 1)]
-lowercase_letters = [chr(i) for i in range(ord("a"), ord("z") + 1)]
-special_chars = list(string.punctuation)
-
-char_selection = [capital_letters, lowercase_letters, special_chars]
+char_selection = [string.ascii_uppercase, string.ascii_lowercase, string.punctuation]
 
 
 class AudioEditorComponent(input_method_proto.IInputMethod):


### PR DESCRIPTION
While trying to update wasd to work with the new changes, I noticed the code in audio_style_input was doing extra work by not using more of the builtin string constants, so this fixes it. Since strings are lists of strings, there's also no need to convert them to lists either. 