### PR TITLE
Improve the typing in config.py

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,10 +1,23 @@
+from typing import TypedDict
+
 from audio_style_input import AudioEditorComponent
+from input_method_proto import IInputMethod
 
 PROJECT_NAME: str = "Dynamic Typing"
 PROJECT_DESCRIPTION: str = "How fast can you type?"
 
+
+class InputMethodSpec(TypedDict):
+    """Specifications for an input method to be added to the main page."""
+
+    name: str
+    path: str
+    icon: str
+    component: type[IInputMethod] | None
+
+
 # INPUT METHODS
-INPUT_METHODS: list[dict] = [
+INPUT_METHODS: list[InputMethodSpec] = [
     {
         "name": "Record Player",
         "path": "audio-input",
@@ -32,7 +45,7 @@ INPUT_METHODS: list[dict] = [
 ]
 
 # COLORS
-COLOR_STYLE: dict = {
+COLOR_STYLE: dict[str, str] = {
     "PRIMARY": "",
     "SECONDARY": "",
     "PRIMARY_BG": "",


### PR DESCRIPTION
By using a `TypedDict` for `INPUT_METHODS`, we can make sure that any class given follows the correct interface at type-checking-time