### PR TITLE
Add typing overrides

### DIFF
--- a/src/audio_style_input/__init__.py
+++ b/src/audio_style_input/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import string
 from pathlib import Path
+from typing import override
 
 from nicegui import app, ui
 
@@ -218,6 +219,7 @@ class AudioEditorComponent(IInputMethod):
         self.intro_card.style("display:none")
         self.main_content.style("display:flex")
 
+    @override
     def on_text_update(self, callback: TextUpdateCallback) -> None:
         """Register a callback to be called whenever the text updates.
 

--- a/src/sample_input_method/__init__.py
+++ b/src/sample_input_method/__init__.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from nicegui import ui
 
 from input_method_proto import IInputMethod, TextUpdateCallback
@@ -16,6 +18,7 @@ class SampleInputMethod(IInputMethod):
         self.inp = ui.input("input here")
         self.inp.on_value_change(lambda event: [x(event.value) for x in self.callbacks])
 
+    @override
     def on_text_update(self, callback: TextUpdateCallback) -> None:
         """Call `callback` every time the user input changes."""
         self.callbacks.append(callback)


### PR DESCRIPTION
This only gives a warning if you are using a picky type checker (like I am), but these should be marked as overrides to show they are overriding the base `on_text_update` function.