### PR TITLE
Name text callback type

### DIFF
--- a/src/audio_style_input/__init__.py
+++ b/src/audio_style_input/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
 import string
-from collections.abc import Callable
 from pathlib import Path
 
 from nicegui import app, ui
@@ -21,7 +20,7 @@ class AudioEditorComponent(input_method_proto.IInputMethod):
     """Render the audio editor page with spinning record and letter spinner."""
 
     def __init__(self) -> None:
-        self._text_update_callback: Callable[[str], None] | None = None
+        self._text_update_callback: input_method_proto.TextUpdateCallback | None = None
         self.current_char_selection_index_container = [0]
         self.current_chars_selected = char_selection[0]
         self.current_letter_index_container = [0]
@@ -223,11 +222,11 @@ class AudioEditorComponent(input_method_proto.IInputMethod):
         self.intro_card.style("display:none")
         self.main_content.style("display:flex")
 
-    def on_text_update(self, callback: Callable[[str], None]) -> None:
+    def on_text_update(self, callback: input_method_proto.TextUpdateCallback) -> None:
         """Register a callback to be called whenever the text updates.
 
         Args:
-            callback (Callable[[str], None]): Function called with updated text.
+            callback (TextUpdateCallback): Function called with updated text.
 
         """
         self._text_update_callback = callback

--- a/src/input_method_proto.py
+++ b/src/input_method_proto.py
@@ -1,9 +1,12 @@
-import typing
+from collections.abc import Callable
+from typing import Protocol
+
+type TextUpdateCallback = Callable[[str], None]
 
 
-class IInputMethod(typing.Protocol):
+class IInputMethod(Protocol):
     """An interface for any input method renderable in the WPM test page."""
 
-    def on_text_update(self, callback: typing.Callable[[str], None]) -> None:
+    def on_text_update(self, callback: TextUpdateCallback) -> None:
         """Call `callback` every time the user input changes."""
         raise NotImplementedError

--- a/src/sample_input_method/__init__.py
+++ b/src/sample_input_method/__init__.py
@@ -1,5 +1,3 @@
-import typing
-
 from nicegui import ui
 
 import input_method_proto
@@ -11,13 +9,13 @@ class SampleInputMethod(input_method_proto.IInputMethod):
     Consider using a dataclass instead with any complex state.
     """
 
-    callbacks: list[typing.Callable[[str], None]]
+    callbacks: list[input_method_proto.TextUpdateCallback]
 
     def __init__(self) -> None:
         self.callbacks = []
         self.inp = ui.input("input here")
         self.inp.on_value_change(lambda event: [x(event.value) for x in self.callbacks])
 
-    def on_text_update(self, callback: typing.Callable[[str], None]) -> None:
+    def on_text_update(self, callback: input_method_proto.TextUpdateCallback) -> None:
         """Call `callback` every time the user input changes."""
         self.callbacks.append(callback)


### PR DESCRIPTION
Giving the callback type a name offers a few nice improvements:
- No chance of type errors due to copy/paste errors
- No need for unrelated typing/collections.abc imports
- Clearer information on what the type hint means
- Clearer code once a future refactor is done to move imports to `from input_method_proto import IInputMethod, TextUpdateCallback` style