### PR TITLE
Make wpm_tester.py check that inputed text is equal to target text for timer stop

### DIFF
--- a/src/wpm_tester.py
+++ b/src/wpm_tester.py
@@ -127,7 +127,7 @@ def setup(
         iv.set_text(txt)
         state.text = txt
 
-        if len(txt) == len(text_to_use):
+        if txt == text_to_use:
             elapsed = time.time() - timer.start if timer.start else 0
             if elapsed > 0:
                 wpm = (len(txt) / 5) / (elapsed / 60)


### PR DESCRIPTION
Previously it just checked that the lengths were equal, but that meant the time could be easily cheesed by spamming wrong letters. Since the deadline is close, making the timer not stop unless the inputed text is perfect is the easiest solution.