### PR TITLE
Clean up comments in main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,13 +3,7 @@ from nicegui import ui
 from homepage import home
 from wpm_tester import wpm_tester_page
 
-###from rpg_text_input import rpg_text_input_page so it doesnt think it's code
-
-
 ui.page("/")(home)
 ui.page("/test/{method}")(wpm_tester_page)
-
-# http://localhost:8080/test/audio_input
-
 
 ui.run()


### PR DESCRIPTION
Neither of these comments are needed anymore since `rpg_text_input_page` is long gone and we now have the home page for navigating to the input methods