### PR TITLE
Make wpm_tester.py header project name into a link

### DIFF
--- a/src/wpm_tester.py
+++ b/src/wpm_tester.py
@@ -48,8 +48,8 @@ def create_header() -> None:
         with ui.card().props("flat"):  # small logo placeholder
             pass
         (
-            ui.label(PROJECT_NAME.upper())
-            .style(f"color: {COLOR_STYLE['primary']}; font-family: Arial, sans-serif;")
+            ui.link(PROJECT_NAME.upper(), "/")
+            .style(f"color: {COLOR_STYLE['primary']}; font-family: Arial, sans-serif; text-decoration: none")
             .classes("text-4xl font-bold")
         )
         ui.button(on_click=lambda: right_drawer.toggle(), icon="menu").props("flat color=white")


### PR DESCRIPTION
I expected this to be clickable to go back to the homepage based on prior muscle memory, so this PR makes the project name at the top of the `wpm_tester` header into that link. `text-decoration: none` is used to keep the switch from label -> link from affecting the looks.