### PR TITLE
Make rpg_style_input keys more readable

### DIFF
--- a/src/rpg_text_input/__init__.py
+++ b/src/rpg_text_input/__init__.py
@@ -93,8 +93,8 @@ class Keyboard(IInputMethod):
                     ):
                         (
                             ui.label(char)
-                            .style("font-size: clamp(1rem, 2vh, 2rem)")
-                            .classes(f"text-center font-bold text-[{config.COLOR_STYLE['contrast']}] p-2")
+                            .style("font-size: clamp(1rem, 3vh, 3rem)")
+                            .classes(f"text-center text-[{config.COLOR_STYLE['contrast']}] p-2")
                         )
 
     def move(self, x: int, y: int) -> None:


### PR DESCRIPTION
It might just be my tired eyes, but I have a really hard time reading the letters with the combination of small + bold. For me, making the desired size 1 bigger and removing the bold makes them so much more readable.

Old:
<img width="1217" height="367" alt="image" src="https://github.com/user-attachments/assets/4abe251c-e027-46b4-b1a7-ebf5e20ea61b" />

New:
<img width="1190" height="354" alt="image" src="https://github.com/user-attachments/assets/8954ef97-1674-4efe-873e-5d2026c189b5" />
