### PR TITLE
Update keyboard docstring to remove raises

### DIFF
--- a/src/rpg_text_input/__init__.py
+++ b/src/rpg_text_input/__init__.py
@@ -56,10 +56,6 @@ class Keyboard(IInputMethod):
     r"""A RPG-style keyboard where characters are selected by navigating with wasd/the arror keys.
 
     Positions are stored internally as (col, row).
-
-    Raises:
-        ValueError: If input keys is non-rectangular (jagged) or starting position is outside keys.
-
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
Since the `__post_init__` was removed, the docstring no long needs a `raises` section