### PR TITLE
Fix config.py platformer entry formatting

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -45,7 +45,12 @@ INPUT_METHODS: list[InputMethodSpec] = [
         "icon": "",
         "component": None,
     },
-    {"name": "Platformer", "path": "platformer", "icon": "", "component": PlatformerInputMethod},
+    {
+        "name": "Platformer",
+        "path": "platformer",
+        "icon": "",
+        "component": PlatformerInputMethod,
+    },
 ]
 
 # COLORS


### PR DESCRIPTION
Normalizes the formatting between the entries in `config.py` by making it format to multiple lines with a trailing comma