### PR TITLE
Make platformer work with wasd and spacebar

### DIFF
--- a/src/platformer_input/__init__.py
+++ b/src/platformer_input/__init__.py
@@ -7,7 +7,6 @@ import input_method_proto
 from platformer_input.platformer_scene_cmp import PlatformerRendererComponent
 from platformer_input.platformer_simulation import PlatformerPhysicsSimulation
 
-ALLOWED_KEYS = ("ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Shift", " ", "Enter")
 INITIAL_POS = (1, 10)
 FPS = 60
 
@@ -38,8 +37,8 @@ class PlatformerInputMethod(input_method_proto.IInputMethod):
 
     def keyboard_handler(self, event: nicegui.events.KeyEventArguments) -> None:
         """Call with the nicegui keyboard callback."""
-        evk = str(event.key)
-        if event.action.repeat or evk not in ALLOWED_KEYS:
+        evk = event.key.code
+        if event.action.repeat:
             return
 
         if event.action.keydown:

--- a/src/platformer_input/platformer_simulation.py
+++ b/src/platformer_input/platformer_simulation.py
@@ -63,11 +63,13 @@ class PlatformerPhysicsSimulation:
 
         delta_accel = self._deltatime * constants.ACCEL_SPEED
 
-        if "ArrowRight" in self._keys:
+        if "ArrowRight" in self._keys or "KeyD" in self._keys:
             self._xvel = min(constants.MOV_SPEED, self._xvel + delta_accel)
-        if "ArrowLeft" in self._keys:
+        if "ArrowLeft" in self._keys or "KeyA" in self._keys:
             self._xvel = max(-constants.MOV_SPEED, self._xvel - delta_accel)
-        if "ArrowUp" in self._keys and self._collides((self.player_x, self.player_y + 2 * EPSILON)):
+        if ("ArrowUp" in self._keys or "KeyW" in self._keys or "Space" in self._keys) and self._collides(
+            (self.player_x, self.player_y + 2 * EPSILON)
+        ):
             self._yvel = -constants.JUMP_FORCE
 
         self._apply_x_velocity()


### PR DESCRIPTION
I made a few additional changes to make making the changes easier:
- Removed `ALLOWED_KEYS`, since there wasn't a point to restricting the keys that get passed to the simulation, and removes a place where data would have to be synchronized manually, preventing bugs
- Switch to `event.key.code` since that makes key strings consistent regardless of if modifiers like shift/ctrl are pressed
- Add the new key codes for wasd and spacebar